### PR TITLE
Remove explicit Font Awesome CSS overrides

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -6,7 +6,6 @@ body.game{
   @import "scaffolding/context-menu";
   @import "scaffolding/control";
   @import "scaffolding/date-selector";
-  @import "scaffolding/font-awesome";
   @import "scaffolding/form-groups";
   @import "scaffolding/foundry-application";
   @import "scaffolding/foundry-core";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,7 @@ module.exports = {
         }),
         new MangleCssClassPlugin({
             classNameRegExp: 'fsc-[a-z\-][a-zA-Z0-9_\-]*',
-            reserveClassName: ['fa', 'fas', 'far'],
+            reserveClassName: ['fa', 'fas', 'far', 'fa-solid', 'fa-regular', 'fa-brands'],
             ignorePrefix: ['fsc-']
         }),
         new RemoveEmptyScriptsPlugin(),


### PR DESCRIPTION
FoundryVTT V14 includes its own Font Awesome 6 and sets the font-family properties properly for fa-solid. Simple Calendar's hardcoded override was breaking it.

Also updated MangleCssClassPlugin to preserve the new fa-solid, fa-regular, and fa-brands classes.