### PR TITLE
Fix missing dropdown icon in day navigation

### DIFF
--- a/src/classes/renderer/date-time-controls.ts
+++ b/src/classes/renderer/date-time-controls.ts
@@ -119,7 +119,7 @@ export class DateTimeControls {
             }
             html += `<div class="fsc-control-group fsc-adjustable-controls">`;
             for (let i = 0; i < btn.length; i++) {
-                html += `<button class="fsc-control fsc-primary" data-tooltip="${btn[i].amount} ${btn[i].tooltip}" data-type="${btn[i].type}" data-amount="${btn[i].amount}">${btn[i].amount}&nbsp;${btn[i].text}</button>`;
+                html += `<button class="fsc-control fsc-primary fsc-selector" data-tooltip="${btn[i].amount} ${btn[i].tooltip}" data-type="${btn[i].type}" data-amount="${btn[i].amount}">${btn[i].amount}&nbsp;${btn[i].text}</button>`;
             }
             html += `</div>`;
         }


### PR DESCRIPTION
Added 'fsc-selector' class to the day button rendering to correctly show the dropdown arrow.